### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/loadSecrets.mjs
+++ b/loadSecrets.mjs
@@ -33,5 +33,5 @@ export default async function loadSecrets() {
     return JSON.stringify(secrets);
 }
 loadSecrets().then((secrets) => {
-    console.log(secrets);
+    // Do not log sensitive secrets to console
 });


### PR DESCRIPTION
Potential fix for [https://github.com/data-altinn-no/k6-tests/security/code-scanning/1](https://github.com/data-altinn-no/k6-tests/security/code-scanning/1)

To avoid leaking sensitive information, secrets containing credentials—such as `tokenPassword`, `tokenUsername`, certificate data, etc.—should not be output to any log. The specific fix is to prevent the complete secrets object from being logged (as it currently is on line 36), or to redact/mask sensitive fields if it's necessary to log for debugging. The best practice is to avoid logging secrets entirely. If logging the basic structure is necessary for diagnostics (for example, other non-sensitive settings), then only non-sensitive fields (e.g., `env`, `useToken`) should be logged, not the secrets themselves.

You should either:
- remove the logging statement on line 36 entirely,
- or, if some logging is required, redact the sensitive fields before logging (e.g., replace passwords with asterisks or omit them).

Since the log is the only sink for this data, and the function already returns the secrets for the caller, it's best to simply remove or comment out line 36, or replace it with a log statement that does not include sensitive fields.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
